### PR TITLE
bug fix: wasn't nulling out existingEntry after a rename when the new DN

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-version "0.24.1-SNAPSHOT"
+version "0.24.2-SNAPSHOT"
 group "edu.berkeley.calnet.groovy.libs"
 
 apply plugin: "groovy"

--- a/src/main/groovy/edu/berkeley/bidms/connector/ldap/LdapConnector.groovy
+++ b/src/main/groovy/edu/berkeley/bidms/connector/ldap/LdapConnector.groovy
@@ -1096,10 +1096,10 @@ class LdapConnector implements Connector {
                         existingEntry = lookup(eventId, (LdapObjectDefinition) objectDef, (LdapCallbackContext) context, dn)
                     }
                     catch (NameNotFoundException ignored) {
-                        // no-op
+                        existingEntry = null
                     }
                     if (!existingEntry) {
-                        throw new LdapConnectorException("Unable to lookup $dn right after an existing object was renamed to this DN")
+                        throw new LdapConnectorException("Unable to lookup $dn right after an existing object was renamed to this DN from the old $existingDn")
                     }
                     isModified = true
                     wasRenamed = true


### PR DESCRIPTION
couldn't be found.